### PR TITLE
Fix PropertyPath exception when passing a numbered array

### DIFF
--- a/src/Router/MappablePropertyPathResolver.php
+++ b/src/Router/MappablePropertyPathResolver.php
@@ -58,7 +58,7 @@ class MappablePropertyPathResolver implements ParameterResolverInterface
 
         return isset($this->mapping[$class][$name])
             || isset($this->mapping[$class]['_fallback'])
-            || $this->propertyAccessor->isReadable($entity, $name);
+            || (is_string($name) && $this->propertyAccessor->isReadable($entity, $name));
     }
 
     /**

--- a/test/Router/MappablePropertyPathResolverTest.php
+++ b/test/Router/MappablePropertyPathResolverTest.php
@@ -86,6 +86,8 @@ class MappablePropertyPathResolverTest extends \PHPUnit_Framework_TestCase
             ['id', new UserSTub(410, 'henkje')],
             ['username', new UserStub(410, 'henkje')],
             ['henk', new UserStub(410, 'henkje'), false],
+
+            [1, new UserStub(410, 'henkje'), false],
         ];
     }
 


### PR DESCRIPTION
If you pass a numbered array to the generator (e.g. `$router->generate('acme_something', [new TestObj(....)])`), you'll get a PropertyPath exception as a number is passed as property path (instead of the expected string or PropertyPath instance).

Also changed the tests to use data providers, as that's a lot easier to debug.