### PR TITLE
Return original value if no resolver supported parameter

### DIFF
--- a/src/Router/ResolverCollection.php
+++ b/src/Router/ResolverCollection.php
@@ -29,16 +29,18 @@ final class ResolverCollection implements ResolverCollectionInterface
         $resolved = [];
 
         foreach ($parameters as $key => $value) {
+            // default to the original value, in case no resolver supports the parameter
+            $resolved[$key] = $value;
+
             // no need to resolve scalars to another value
-            $resolved[$key] = is_scalar($value) ? $value : null;
+            if (is_scalar($value)) {
+                continue;
+            }
 
             foreach ($this->resolvers as $resolver) {
-                if (null !== $resolved[$key]) {
-                    break;
-                }
-
                 if ($resolver->supportsParameter($key, $value)) {
                     $resolved[$key] = $resolver->resolveParameter($key, $value);
+                    break;
                 }
             }
         }

--- a/test/Router/ResolverCollectionTest.php
+++ b/test/Router/ResolverCollectionTest.php
@@ -36,6 +36,13 @@ class ResolverCollectionTest extends \PHPUnit_Framework_TestCase
                     return 'henk';
                 })
             ],
+            [
+                ['user' => new \stdClass()],
+                ['user' => new \stdClass()],
+                new CallableResolver(function () {
+                    return false;
+                }, function () { })
+            ],
         ];
     }
 }


### PR DESCRIPTION
When no resolver supports a parameter, I believe the original value should be returned (maybe the user uses a custom URL generator which does support the parameter). In the current code, `null` is returned instead.