### PR TITLE
Changed phpunit asserts to static usage

### DIFF
--- a/test/DependencyInjection/DecorateRouterPassTest.php
+++ b/test/DependencyInjection/DecorateRouterPassTest.php
@@ -33,7 +33,7 @@ class DecorateRouterPassTest extends \PHPUnit_Framework_TestCase
             ->addTag('router.parameter_resolver');
 
         $pass->process($container);
-        $this->assertFalse($container->has('iltar_http.parameter_resolving_router'));
+        self::assertFalse($container->has('iltar_http.parameter_resolving_router'));
     }
 
     public function testProcessNoResolvers()
@@ -48,7 +48,7 @@ class DecorateRouterPassTest extends \PHPUnit_Framework_TestCase
 
         $pass->process($this->container);
 
-        $this->assertTrue($this->container->has('iltar_http.parameter_resolving_router'));
+        self::assertTrue($this->container->has('iltar_http.parameter_resolving_router'));
     }
 
     public function testProcessMissingPriorityTag()
@@ -65,8 +65,8 @@ class DecorateRouterPassTest extends \PHPUnit_Framework_TestCase
 
         $pass->process($this->container);
 
-        $this->assertTrue($this->container->has('iltar_http.parameter_resolving_router'));
-        $this->assertTrue($this->container->has('iltar_http.parameter_resolver.app.henk'));
+        self::assertTrue($this->container->has('iltar_http.parameter_resolving_router'));
+        self::assertTrue($this->container->has('iltar_http.parameter_resolver.app.henk'));
     }
 
     public function testProcess()
@@ -107,7 +107,7 @@ class DecorateRouterPassTest extends \PHPUnit_Framework_TestCase
         $resolvers = $this->container->getDefinition('iltar_http.router.parameter_resolver_collection')->getArgument(0);
 
         foreach ($expectedResolvers as $i => $resolver) {
-            $this->assertSame($resolver, $resolvers[$i]->__toString());
+            self::assertSame($resolver, $resolvers[$i]->__toString());
         }
     }
 }

--- a/test/DependencyInjection/IltarHttpExtensionTest.php
+++ b/test/DependencyInjection/IltarHttpExtensionTest.php
@@ -16,9 +16,9 @@ class IltarHttpExtensionTest extends \PHPUnit_Framework_TestCase
         $container = new ContainerBuilder();
         $ext->load([], $container);
 
-        $this->assertTrue($container->has('iltar_http.router.parameter_resolver_collection'));
-        $this->assertTrue($container->hasParameter('iltar_http.router.enabled'));
-        $this->assertFalse($container->hasParameter('iltar_http.router.entity_id_resolver.enabled'));
+        self::assertTrue($container->has('iltar_http.router.parameter_resolver_collection'));
+        self::assertTrue($container->hasParameter('iltar_http.router.enabled'));
+        self::assertFalse($container->hasParameter('iltar_http.router.entity_id_resolver.enabled'));
     }
 
     public function testLoadMappedResolvers()
@@ -59,7 +59,7 @@ class IltarHttpExtensionTest extends \PHPUnit_Framework_TestCase
             ],
         ];
 
-        $this->assertSame($expected, $container->getDefinition('iltar_http.router.mapped_properties')->getArgument(1));
+        self::assertSame($expected, $container->getDefinition('iltar_http.router.mapped_properties')->getArgument(1));
     }
 
     public function testLoadWithEntityIdResolver()
@@ -68,9 +68,9 @@ class IltarHttpExtensionTest extends \PHPUnit_Framework_TestCase
         $container = new ContainerBuilder();
         $ext->load(['iltar_http' => ['router' => ['entity_id_resolver' => true]]], $container);
 
-        $this->assertTrue($container->hasParameter('iltar_http.router.enabled'));
-        $this->assertTrue($container->hasParameter('iltar_http.router.entity_id_resolver.enabled'));
-        $this->assertTrue($container->has('iltar_http.router.entity_id_resolver'));
+        self::assertTrue($container->hasParameter('iltar_http.router.enabled'));
+        self::assertTrue($container->hasParameter('iltar_http.router.entity_id_resolver.enabled'));
+        self::assertTrue($container->has('iltar_http.router.entity_id_resolver'));
     }
 
     public function testLoadNoRouter()
@@ -79,7 +79,7 @@ class IltarHttpExtensionTest extends \PHPUnit_Framework_TestCase
         $container = new ContainerBuilder();
         $ext->load(['iltar_http' => ['router' => ['enabled' => false]]], $container);
 
-        $this->assertFalse($container->has('iltar_http.router.parameter_resolver_collection'));
-        $this->assertFalse($container->hasParameter('iltar_http.router.enabled'));
+        self::assertFalse($container->has('iltar_http.router.parameter_resolver_collection'));
+        self::assertFalse($container->hasParameter('iltar_http.router.enabled'));
     }
 }

--- a/test/DoctrineBridge/Router/EntityIdResolverTest.php
+++ b/test/DoctrineBridge/Router/EntityIdResolverTest.php
@@ -15,7 +15,7 @@ class EntityIdResolverTest extends \PHPUnit_Framework_TestCase
         $manager  = $this->prophesize(ManagerRegistry::class);
         $resolver = new EntityIdResolver($manager->reveal());
 
-        $this->assertFalse($resolver->supportsParameter('user', ['id' => 400]));
+        self::assertFalse($resolver->supportsParameter('user', ['id' => 400]));
     }
 
     public function testObjectNotEntity()
@@ -26,11 +26,11 @@ class EntityIdResolverTest extends \PHPUnit_Framework_TestCase
 
         $manager->getRepository(get_class($object->reveal()))->shouldBeCalled()->willThrow(new MappingException());
 
-        $this->assertFalse($resolver->supportsParameter('user', $object->reveal()));
+        self::assertFalse($resolver->supportsParameter('user', $object->reveal()));
 
         // should hit the cache
-        $this->assertFalse($resolver->supportsParameter('user', $object->reveal()));
-        $this->assertAttributeSame([get_class($object->reveal()) => false], 'resolvedCache', $resolver);
+        self::assertFalse($resolver->supportsParameter('user', $object->reveal()));
+        self::assertAttributeSame([get_class($object->reveal()) => false], 'resolvedCache', $resolver);
     }
 
     /**
@@ -44,7 +44,7 @@ class EntityIdResolverTest extends \PHPUnit_Framework_TestCase
 
         $manager->getRepository(get_class($entity))->shouldBeCalled();
 
-        $this->assertTrue($resolver->supportsParameter('user', $entity));
+        self::assertTrue($resolver->supportsParameter('user', $entity));
         $resolver->resolveParameter('user', $entity);
     }
 
@@ -57,12 +57,12 @@ class EntityIdResolverTest extends \PHPUnit_Framework_TestCase
         $manager->getRepository(get_class($entity->reveal()))->shouldBeCalled();
         $entity->getId()->willReturn(420);
 
-        $this->assertTrue($resolver->supportsParameter('user', $entity->reveal()));
-        $this->assertSame('420', $resolver->resolveParameter('user', $entity->reveal()));
+        self::assertTrue($resolver->supportsParameter('user', $entity->reveal()));
+        self::assertSame('420', $resolver->resolveParameter('user', $entity->reveal()));
 
         // should hit the cache
-        $this->assertTrue($resolver->supportsParameter('user', $entity->reveal()));
-        $this->assertAttributeSame([get_class($entity->reveal()) => true], 'resolvedCache', $resolver);
+        self::assertTrue($resolver->supportsParameter('user', $entity->reveal()));
+        self::assertAttributeSame([get_class($entity->reveal()) => true], 'resolvedCache', $resolver);
     }
 }
 

--- a/test/Functional/RouteGenerationTest.php
+++ b/test/Functional/RouteGenerationTest.php
@@ -21,7 +21,7 @@ class RouteGenerationTest extends KernelTestCase
     {
         $router = static::$kernel->getContainer()->get('router');
 
-        $this->assertEquals($expectedPath, $router->generate($routeName, $routeParameters));
+        self::assertEquals($expectedPath, $router->generate($routeName, $routeParameters));
     }
 
     public function getPropertyPathResolverData()

--- a/test/IltarHttpBundleTest.php
+++ b/test/IltarHttpBundleTest.php
@@ -18,6 +18,6 @@ class IltarHttpBundleTest extends \PHPUnit_Framework_TestCase
         $bundle->build($container);
 
         $passes = $container->getCompiler()->getPassConfig()->getBeforeOptimizationPasses();
-        $this->assertInstanceOf(DecorateRouterPass::class, $passes[0]);
+        self::assertInstanceOf(DecorateRouterPass::class, $passes[0]);
     }
 }

--- a/test/Router/MappablePropertyPathResolverTest.php
+++ b/test/Router/MappablePropertyPathResolverTest.php
@@ -29,7 +29,7 @@ class MappablePropertyPathResolverTest extends \PHPUnit_Framework_TestCase
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
         $resolver         = new MappablePropertyPathResolver($propertyAccessor, self::$mapping);
 
-        $this->assertEquals($supported, $resolver->supportsParameter($name, $parameter));
+        self::assertEquals($supported, $resolver->supportsParameter($name, $parameter));
     }
 
     public function getSupportsData()
@@ -54,7 +54,7 @@ class MappablePropertyPathResolverTest extends \PHPUnit_Framework_TestCase
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
         $resolver = new MappablePropertyPathResolver($propertyAccessor, self::$mapping);
 
-        $this->assertSame($resolvedValue, $resolver->resolveParameter($name, $parameter));
+        self::assertSame($resolvedValue, $resolver->resolveParameter($name, $parameter));
     }
 
     public function getResolveData()
@@ -77,7 +77,7 @@ class MappablePropertyPathResolverTest extends \PHPUnit_Framework_TestCase
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
         $resolver         = new MappablePropertyPathResolver($propertyAccessor, []);
 
-        $this->assertEquals($supported, $resolver->supportsParameter($name, $parameter));
+        self::assertEquals($supported, $resolver->supportsParameter($name, $parameter));
     }
 
     public function getUnmappedSupportsData()
@@ -97,7 +97,7 @@ class MappablePropertyPathResolverTest extends \PHPUnit_Framework_TestCase
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
         $resolver = new MappablePropertyPathResolver($propertyAccessor, []);
 
-        $this->assertSame($resolvedValue, $resolver->resolveParameter($name, $parameter));
+        self::assertSame($resolvedValue, $resolver->resolveParameter($name, $parameter));
     }
 
     public function getUnmappedResolveData()

--- a/test/Router/ParameterResolvingRouterTest.php
+++ b/test/Router/ParameterResolvingRouterTest.php
@@ -32,11 +32,11 @@ class ParameterResolvingRouterTest extends \PHPUnit_Framework_TestCase
 
         $router = new ParameterResolvingRouter($decorated->reveal(), $collection->reveal());
         $router->setContext($context->reveal());
-        $this->assertSame($context->reveal(), $router->getContext());
-        $this->assertSame($routes->reveal(), $router->getRouteCollection());
-        $this->assertTrue($router->match('/path-matcher'));
-        $this->assertTrue($router->matchRequest($request->reveal()));
-        $this->assertEquals('/returned/path/', $router->generate('app.route'));
+        self::assertSame($context->reveal(), $router->getContext());
+        self::assertSame($routes->reveal(), $router->getRouteCollection());
+        self::assertTrue($router->match('/path-matcher'));
+        self::assertTrue($router->matchRequest($request->reveal()));
+        self::assertEquals('/returned/path/', $router->generate('app.route'));
     }
 
     /**
@@ -48,6 +48,6 @@ class ParameterResolvingRouterTest extends \PHPUnit_Framework_TestCase
         $collection = $this->prophesize(ResolverCollectionInterface::class);
         $request    = $this->prophesize(Request::class);
         $router     = new ParameterResolvingRouter($decorated->reveal(), $collection->reveal());
-        $this->assertTrue($router->matchRequest($request->reveal()));
+        self::assertTrue($router->matchRequest($request->reveal()));
     }
 }

--- a/test/Router/ResolverCollectionTest.php
+++ b/test/Router/ResolverCollectionTest.php
@@ -12,7 +12,7 @@ class ResolverCollectionTest extends \PHPUnit_Framework_TestCase
      */
     public function testResolve(array $input, array $expected, CallableResolver $resolver)
     {
-        $this->assertEquals($expected, (new ResolverCollection([$resolver]))->resolve($input));
+        self::assertEquals($expected, (new ResolverCollection([$resolver]))->resolve($input));
     }
 
     public function resolveProvider()


### PR DESCRIPTION
PHPUnit has defined the assert methods being static, therefore should be called static. 