### PR TITLE
The var directory is now used for the cache instead of nested

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 # PHPUnit
 /phpunit.xml
 coverage/
-/test/Functional/Fixtures/cache
-/test/Functional/Fixtures/logs
+/var
 
 # composer
 /vendor/

--- a/test/Functional/Fixtures/TestKernel.php
+++ b/test/Functional/Fixtures/TestKernel.php
@@ -26,4 +26,20 @@ class TestKernel extends Kernel
     {
         $loader->load(__DIR__.'/config/config.yml');
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCacheDir()
+    {
+        return __DIR__.'/../../../var/cache/'.$this->getEnvironment();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLogDir()
+    {
+        return __DIR__.'/../../../var/logs';
+    }
 }


### PR DESCRIPTION
Instead of nesting all geberated logs/cache stuff somewhere deep in the structure, put it in the var directory in the project root. 