### PR TITLE
Fixed codestyle with cs.sensiolabs.org

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Iltar\HttpBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
@@ -10,14 +11,13 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
-
     /**
      * {@inheritdoc}
      */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode    = $treeBuilder->root('iltar_http');
+        $rootNode = $treeBuilder->root('iltar_http');
 
         $this->addRouterConfig($rootNode);
 
@@ -25,7 +25,7 @@ class Configuration implements ConfigurationInterface
     }
 
     /**
-     * Resolves iltar_http.router
+     * Resolves iltar_http.router.
      *
      * @param ArrayNodeDefinition $rootNode
      */

--- a/src/DependencyInjection/DecorateRouterPass.php
+++ b/src/DependencyInjection/DecorateRouterPass.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Iltar\HttpBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -31,7 +32,7 @@ final class DecorateRouterPass implements CompilerPassInterface
 
             $resolvers[] = [
                 'priority' => $tag['priority'],
-                'service'  => $serviceId
+                'service' => $serviceId,
             ];
         }
 

--- a/src/DependencyInjection/IltarHttpExtension.php
+++ b/src/DependencyInjection/IltarHttpExtension.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Iltar\HttpBundle\DependencyInjection;
 
 use Iltar\HttpBundle\DoctrineBridge\Router\EntityIdResolver;
@@ -59,6 +60,7 @@ final class IltarHttpExtension extends Extension
 
     /**
      * @param array $mapping
+     *
      * @return array
      */
     private function convertMappedGetters(array $mapping)

--- a/src/DoctrineBridge/Router/EntityIdResolver.php
+++ b/src/DoctrineBridge/Router/EntityIdResolver.php
@@ -72,4 +72,3 @@ final class EntityIdResolver implements ParameterResolverInterface
         return (string) $callable();
     }
 }
-

--- a/src/Exception/UncallableMethodException.php
+++ b/src/Exception/UncallableMethodException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Iltar\HttpBundle\Exception;
 
 /**

--- a/src/IltarHttpBundle.php
+++ b/src/IltarHttpBundle.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Iltar\HttpBundle;
 
 use Iltar\HttpBundle\DependencyInjection\DecorateRouterPass;

--- a/src/Router/MappablePropertyPathResolver.php
+++ b/src/Router/MappablePropertyPathResolver.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Iltar\HttpBundle\Router;
 
 use Symfony\Component\PropertyAccess\PropertyAccessor;
@@ -40,7 +41,7 @@ class MappablePropertyPathResolver implements ParameterResolverInterface
     public function __construct(PropertyAccessor $propertyAccessor, array $mapping)
     {
         $this->propertyAccessor = $propertyAccessor;
-        $this->mapping          = $mapping;
+        $this->mapping = $mapping;
     }
 
     /**

--- a/src/Router/ParameterResolverInterface.php
+++ b/src/Router/ParameterResolverInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Iltar\HttpBundle\Router;
 
 /**
@@ -11,8 +12,9 @@ interface ParameterResolverInterface
     /**
      * Check if the parameter is supported.
      *
-     * @param string $name   Name of the parameter as defined in the Route
-     * @param mixed  $value  Value of the parameter as filled in
+     * @param string $name  Name of the parameter as defined in the Route
+     * @param mixed  $value Value of the parameter as filled in
+     *
      * @return bool
      */
     public function supportsParameter($name, $value);
@@ -25,9 +27,10 @@ interface ParameterResolverInterface
      *  - generate("app.profile.view", ["username" => $user])
      *  - { return $user->getUsername(); }
      *
-     * @param string $name   Name of the parameter as defined in the Route
-     * @param mixed  $value  Value of the parameter as filled in
-     * @return string|null   Return null if nothing could be resolved
+     * @param string $name  Name of the parameter as defined in the Route
+     * @param mixed  $value Value of the parameter as filled in
+     *
+     * @return string|null Return null if nothing could be resolved
      */
     public function resolveParameter($name, $value);
 }

--- a/src/Router/ParameterResolvingRouter.php
+++ b/src/Router/ParameterResolvingRouter.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Iltar\HttpBundle\Router;
 
 use Symfony\Component\HttpFoundation\Request;
@@ -28,7 +29,7 @@ final class ParameterResolvingRouter implements RouterInterface, RequestMatcherI
      */
     public function __construct(RouterInterface $router, ResolverCollectionInterface $resolverCollection)
     {
-        $this->router             = $router;
+        $this->router = $router;
         $this->resolverCollection = $resolverCollection;
     }
 

--- a/src/Router/ResolverCollection.php
+++ b/src/Router/ResolverCollection.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Iltar\HttpBundle\Router;
 
 /**

--- a/src/Router/ResolverCollectionInterface.php
+++ b/src/Router/ResolverCollectionInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Iltar\HttpBundle\Router;
 
 /**
@@ -9,7 +10,8 @@ interface ResolverCollectionInterface
     /**
      * Resolves a set of parameters.
      *
-     * @param array $parameters   to be resolved
+     * @param array $parameters to be resolved
+     *
      * @return array
      */
     public function resolve(array $parameters);

--- a/test/DependencyInjection/DecorateRouterPassTest.php
+++ b/test/DependencyInjection/DecorateRouterPassTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Iltar\HttpBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
@@ -25,7 +26,7 @@ class DecorateRouterPassTest extends \PHPUnit_Framework_TestCase
 
     public function testProcessNotEnabled()
     {
-        $pass      = new DecorateRouterPass();
+        $pass = new DecorateRouterPass();
         $container = new ContainerBuilder();
         $container
             ->register('app.henk')

--- a/test/DependencyInjection/IltarHttpExtensionTest.php
+++ b/test/DependencyInjection/IltarHttpExtensionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Iltar\HttpBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -12,7 +13,7 @@ class IltarHttpExtensionTest extends \PHPUnit_Framework_TestCase
 {
     public function testLoadWithRouter()
     {
-        $ext       = new IltarHttpExtension();
+        $ext = new IltarHttpExtension();
         $container = new ContainerBuilder();
         $ext->load([], $container);
 
@@ -23,22 +24,22 @@ class IltarHttpExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testLoadMappedResolvers()
     {
-        $ext       = new IltarHttpExtension();
+        $ext = new IltarHttpExtension();
         $container = new ContainerBuilder();
         $ext->load([
             'iltar_http' => [
                 'router' => [
                     'mapped_properties' => [
-                        'App\Post'          => 'slug',
-                        'App\User'          => 'id',
-                        'App\User.user'     => 'username',
+                        'App\Post' => 'slug',
+                        'App\User' => 'id',
+                        'App\User.user' => 'username',
                         'App\User.username' => '~',
-                        'App\Reply.rid'     => 'id',
-                        'App\Reply.id'      => null,
+                        'App\Reply.rid' => 'id',
+                        'App\Reply.id' => null,
                         'App\Message.re.id' => 'id',
-                    ]
-                ]
-            ]
+                    ],
+                ],
+            ],
         ], $container);
 
         $expected = [
@@ -47,12 +48,12 @@ class IltarHttpExtensionTest extends \PHPUnit_Framework_TestCase
             ],
             'App\User' => [
                 '_fallback' => 'id',
-                'user'      => 'username',
-                'username'  => 'username',
+                'user' => 'username',
+                'username' => 'username',
             ],
             'App\Reply' => [
                 'rid' => 'id',
-                'id'  => 'id',
+                'id' => 'id',
             ],
             'App\Message' => [
                 're.id' => 'id',
@@ -64,7 +65,7 @@ class IltarHttpExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testLoadWithEntityIdResolver()
     {
-        $ext       = new IltarHttpExtension();
+        $ext = new IltarHttpExtension();
         $container = new ContainerBuilder();
         $ext->load(['iltar_http' => ['router' => ['entity_id_resolver' => true]]], $container);
 
@@ -75,7 +76,7 @@ class IltarHttpExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testLoadNoRouter()
     {
-        $ext       = new IltarHttpExtension();
+        $ext = new IltarHttpExtension();
         $container = new ContainerBuilder();
         $ext->load(['iltar_http' => ['router' => ['enabled' => false]]], $container);
 

--- a/test/DoctrineBridge/Router/EntityIdResolverTest.php
+++ b/test/DoctrineBridge/Router/EntityIdResolverTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Iltar\HttpBundle\DoctrineBridge\Router;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
@@ -12,7 +13,7 @@ class EntityIdResolverTest extends \PHPUnit_Framework_TestCase
 {
     public function testArray()
     {
-        $manager  = $this->prophesize(ManagerRegistry::class);
+        $manager = $this->prophesize(ManagerRegistry::class);
         $resolver = new EntityIdResolver($manager->reveal());
 
         self::assertFalse($resolver->supportsParameter('user', ['id' => 400]));
@@ -20,8 +21,8 @@ class EntityIdResolverTest extends \PHPUnit_Framework_TestCase
 
     public function testObjectNotEntity()
     {
-        $manager  = $this->prophesize(ManagerRegistry::class);
-        $object   = $this->prophesize(TestObject::class);
+        $manager = $this->prophesize(ManagerRegistry::class);
+        $object = $this->prophesize(TestObject::class);
         $resolver = new EntityIdResolver($manager->reveal());
 
         $manager->getRepository(get_class($object->reveal()))->shouldBeCalled()->willThrow(new MappingException());
@@ -38,8 +39,8 @@ class EntityIdResolverTest extends \PHPUnit_Framework_TestCase
      */
     public function testEntityWithoutId()
     {
-        $manager  = $this->prophesize(ManagerRegistry::class);
-        $entity   = new \stdClass();
+        $manager = $this->prophesize(ManagerRegistry::class);
+        $entity = new \stdClass();
         $resolver = new EntityIdResolver($manager->reveal());
 
         $manager->getRepository(get_class($entity))->shouldBeCalled();
@@ -50,8 +51,8 @@ class EntityIdResolverTest extends \PHPUnit_Framework_TestCase
 
     public function testEntityWithId()
     {
-        $manager  = $this->prophesize(ManagerRegistry::class);
-        $entity   = $this->prophesize(TestEntityWithId::class);
+        $manager = $this->prophesize(ManagerRegistry::class);
+        $entity = $this->prophesize(TestEntityWithId::class);
         $resolver = new EntityIdResolver($manager->reveal());
 
         $manager->getRepository(get_class($entity->reveal()))->shouldBeCalled();

--- a/test/Functional/Fixtures/Model/MappedPost.php
+++ b/test/Functional/Fixtures/Model/MappedPost.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Iltar\HttpBundle\Functional\Fixtures\Model;
 
 /**

--- a/test/Functional/Fixtures/Model/Post.php
+++ b/test/Functional/Fixtures/Model/Post.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Iltar\HttpBundle\Functional\Fixtures\Model;
 
 /**

--- a/test/Functional/RouteGenerationTest.php
+++ b/test/Functional/RouteGenerationTest.php
@@ -1,10 +1,10 @@
 <?php
+
 namespace Iltar\HttpBundle;
 
 use Iltar\HttpBundle\Functional\Fixtures\Model\MappedPost;
 use Iltar\HttpBundle\Functional\Fixtures\Model\Post;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
  * @author Wouter J <wouter@wouterj.nl>

--- a/test/IltarHttpBundleTest.php
+++ b/test/IltarHttpBundleTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Iltar\HttpBundle;
 
 use Iltar\HttpBundle\DependencyInjection\DecorateRouterPass;
@@ -13,7 +14,7 @@ class IltarHttpBundleTest extends \PHPUnit_Framework_TestCase
     public function testBuild()
     {
         $container = new ContainerBuilder();
-        $bundle    = new IltarHttpBundle();
+        $bundle = new IltarHttpBundle();
 
         $bundle->build($container);
 

--- a/test/Router/MappablePropertyPathResolverTest.php
+++ b/test/Router/MappablePropertyPathResolverTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Iltar\HttpBundle\Router;
 
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -11,14 +12,14 @@ class MappablePropertyPathResolverTest extends \PHPUnit_Framework_TestCase
 {
     private static $mapping = [
         UserStub::class => [
-            'username'  => 'username',
+            'username' => 'username',
             '_fallback' => 'id',
         ],
         PostStub::class => [
             '_fallback' => 'slug',
         ],
         ReplyStub::class => [
-            'id'   => 'id',
+            'id' => 'id',
             'slug' => 'post.slug',
         ],
     ];
@@ -27,7 +28,7 @@ class MappablePropertyPathResolverTest extends \PHPUnit_Framework_TestCase
     public function testSupports($name, $parameter, $supported = true)
     {
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
-        $resolver         = new MappablePropertyPathResolver($propertyAccessor, self::$mapping);
+        $resolver = new MappablePropertyPathResolver($propertyAccessor, self::$mapping);
 
         self::assertEquals($supported, $resolver->supportsParameter($name, $parameter));
     }
@@ -75,7 +76,7 @@ class MappablePropertyPathResolverTest extends \PHPUnit_Framework_TestCase
     public function testUnmappedSupports($name, $parameter, $supported = true)
     {
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
-        $resolver         = new MappablePropertyPathResolver($propertyAccessor, []);
+        $resolver = new MappablePropertyPathResolver($propertyAccessor, []);
 
         self::assertEquals($supported, $resolver->supportsParameter($name, $parameter));
     }
@@ -115,7 +116,7 @@ class UserStub
     private $username;
     public function __construct($id, $username)
     {
-        $this->id       = $id;
+        $this->id = $id;
         $this->username = $username;
     }
 
@@ -155,7 +156,7 @@ class ReplyStub
     private $post;
     public function __construct($id, PostStub $post)
     {
-        $this->id   = $id;
+        $this->id = $id;
         $this->post = $post;
     }
 

--- a/test/Router/ParameterResolvingRouterTest.php
+++ b/test/Router/ParameterResolvingRouterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Iltar\HttpBundle\Router;
 
 use Symfony\Component\HttpFoundation\Request;
@@ -16,11 +17,11 @@ class ParameterResolvingRouterTest extends \PHPUnit_Framework_TestCase
 {
     public function testDelegation()
     {
-        $routes     = $this->prophesize(RouteCollection::class);
-        $context    = $this->prophesize(RequestContext::class);
-        $decorated  = $this->prophesize(RouterInterface::class)->willImplement(RequestMatcherInterface::class);
+        $routes = $this->prophesize(RouteCollection::class);
+        $context = $this->prophesize(RequestContext::class);
+        $decorated = $this->prophesize(RouterInterface::class)->willImplement(RequestMatcherInterface::class);
         $collection = $this->prophesize(ResolverCollectionInterface::class);
-        $request    = $this->prophesize(Request::class);
+        $request = $this->prophesize(Request::class);
 
         $decorated->setContext($context)->shouldBeCalled();
         $decorated->getContext()->willReturn($context);
@@ -44,10 +45,10 @@ class ParameterResolvingRouterTest extends \PHPUnit_Framework_TestCase
      */
     public function testMissingMatcher()
     {
-        $decorated  = $this->prophesize(RouterInterface::class);
+        $decorated = $this->prophesize(RouterInterface::class);
         $collection = $this->prophesize(ResolverCollectionInterface::class);
-        $request    = $this->prophesize(Request::class);
-        $router     = new ParameterResolvingRouter($decorated->reveal(), $collection->reveal());
+        $request = $this->prophesize(Request::class);
+        $router = new ParameterResolvingRouter($decorated->reveal(), $collection->reveal());
         self::assertTrue($router->matchRequest($request->reveal()));
     }
 }

--- a/test/Router/ResolverCollectionTest.php
+++ b/test/Router/ResolverCollectionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Iltar\HttpBundle\Router;
 
 /**
@@ -25,7 +26,7 @@ class ResolverCollectionTest extends \PHPUnit_Framework_TestCase
                     return $key === 'user';
                 }, function ($key, $value) {
                     return $value.'-user';
-                })
+                }),
             ],
             [
                 ['user' => new \stdClass()],
@@ -34,14 +35,14 @@ class ResolverCollectionTest extends \PHPUnit_Framework_TestCase
                     return $key === 'user';
                 }, function () {
                     return 'henk';
-                })
+                }),
             ],
             [
                 ['user' => new \stdClass()],
                 ['user' => new \stdClass()],
                 new CallableResolver(function () {
                     return false;
-                }, function () { })
+                }, function () { }),
             ],
         ];
     }
@@ -58,16 +59,17 @@ class CallableResolver implements ParameterResolverInterface
         $this->resolves = $resolves;
     }
 
-
     public function supportsParameter($name, $value)
     {
         $m = $this->supports;
+
         return $m($name, $value);
     }
 
     public function resolveParameter($name, $value)
     {
         $m = $this->resolves;
+
         return $m($name, $value);
     }
 }


### PR DESCRIPTION
Used the tool provided by http://cs.sensiolabs.org/ to fix the codestyle. The idea is to keep the codestyle consistent with the one from symfony itself to make contributions easier.

Command used: 
```
$ php-cs-fixer fix .
```