### PR TITLE
Fixed missing warmup delegation

### DIFF
--- a/src/Router/ParameterResolvingRouter.php
+++ b/src/Router/ParameterResolvingRouter.php
@@ -3,6 +3,7 @@
 namespace Iltar\HttpBundle\Router;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
 use Symfony\Component\Routing\RequestContext;
@@ -11,7 +12,7 @@ use Symfony\Component\Routing\RouterInterface;
 /**
  * @author Iltar van der Berg <kjarli@gmail.com>
  */
-final class ParameterResolvingRouter implements RouterInterface, RequestMatcherInterface
+final class ParameterResolvingRouter implements RouterInterface, RequestMatcherInterface, WarmableInterface
 {
     /**
      * @var RouterInterface
@@ -83,5 +84,15 @@ final class ParameterResolvingRouter implements RouterInterface, RequestMatcherI
         }
 
         return $this->router->matchRequest($request);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function warmUp($cacheDir)
+    {
+        if ($this->router instanceof WarmableInterface) {
+            $this->router->warmUp($cacheDir);
+        }
     }
 }

--- a/test/Router/ParameterResolvingRouterTest.php
+++ b/test/Router/ParameterResolvingRouterTest.php
@@ -3,6 +3,7 @@
 namespace Iltar\HttpBundle\Router;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
 use Symfony\Component\Routing\RequestContext;
@@ -37,6 +38,19 @@ class ParameterResolvingRouterTest extends \PHPUnit_Framework_TestCase
         self::assertTrue($router->match('/path-matcher'));
         self::assertTrue($router->matchRequest($request->reveal()));
         self::assertEquals('/returned/path/', $router->generate('app.route'));
+        self::assertNull($router->warmUp('/'));
+    }
+
+    public function testDelegationForWarmup()
+    {
+        $collection = $this->prophesize(ResolverCollectionInterface::class);
+        $decorated = $this->prophesize(RouterInterface::class)->willImplement(RequestMatcherInterface::class);
+        $decorated->willImplement(WarmableInterface::class);
+        $decorated->warmUp('/tmp')->shouldBeCalled();
+
+        $router = new ParameterResolvingRouter($decorated->reveal(), $collection->reveal());
+
+        self::assertNull($router->warmUp('/tmp'));
     }
 
     /**


### PR DESCRIPTION
When the framework bundle is available, the router in this bundle will implement the `WarmerInterface` and will be called during cache warmup. As this interface is missing in this implementation in the framework bundle, it will not warm the routing cache properly. This causes the first request in the browser to cache the router information instead.