### PR TITLE
Fixed failing on unknown entities

### DIFF
--- a/src/DoctrineBridge/EntityIdDescriptor.php
+++ b/src/DoctrineBridge/EntityIdDescriptor.php
@@ -61,7 +61,9 @@ final class EntityIdDescriptor implements ModelDescriptorInterface
 
         try {
             $this->registry->getRepository($className);
-        } catch (MappingException $e) {
+        } catch (\Exception $e) {
+            return $this->resolvedCache[$className] = false;
+        } catch (\Throwable $e) {
             return $this->resolvedCache[$className] = false;
         }
 

--- a/src/Exception/UnresolvedParameterException.php
+++ b/src/Exception/UnresolvedParameterException.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Iltar\HttpBundle\Exception;
+
+/**
+ * @author Iltar van der Berg <kjarli@gmail.com>
+ */
+class UnresolvedParameterException extends \RuntimeException
+{
+    /**
+     * @var string[]
+     */
+    private $parameters;
+
+    /**
+     * @param string   $route
+     * @param string[] $parameters
+     */
+    public function __construct($route, array $parameters)
+    {
+        parent::__construct(sprintf(
+            'Parameters for the route \'%s\' could not be resolved to scalar values. Parameters: "%s".',
+            $route,
+            implode(', ', array_keys($parameters))
+        ));
+
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getParameters()
+    {
+        return $this->parameters;
+    }
+}

--- a/test/Functional/RouteGenerationTest.php
+++ b/test/Functional/RouteGenerationTest.php
@@ -69,4 +69,21 @@ class RouteGenerationTest extends KernelTestCase
 
         $router->generate('message_route', ['blind_write' => new BlindWrite(10)]);
     }
+
+    /**
+     * @expectedException \Iltar\HttpBundle\Exception\UnresolvedParameterException
+     * @expectedExceptionMessage Parameters for the route 'mapped_fallback_route' could not be resolved to scalar values. Parameters: "object_key, empty_key, array_key, resource_key".
+     */
+    public function testEntityIdResolverWithWithoutAlternatives()
+    {
+        $router = static::$kernel->getContainer()->get('router');
+
+        $router->generate('mapped_fallback_route', [
+            'object_key' => new \stdClass(),
+            'empty_key' => '',
+            'array_key' => [],
+            'normal_key' => '10',
+            'resource_key' => fopen(__FILE__, 'rb'),
+        ]);
+    }
 }


### PR DESCRIPTION
Fixes #23. 

 - By catching more exceptions, the isManaged is more robust.
 - If an unresolvable value is passed to the generator, or it resolves
   to an empty string, it will now fail with a proper exception message.

These fixes solve some DX issues regarding error messages that are unclear as well, though eventually Symfony should probably fix these errors.