### PR TITLE
The resolver should only report errors on values it tries to resolve

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     "doctrine/orm"             : "^2.5",
     "phpunit/phpunit"          : "^4.7||^5.0",
     "symfony/phpunit-bridge"   : "^2.8||^3.0",
+    "symfony/security-http"    : "^2.7||^3.0",
     "symfony/var-dumper"       : "^2.7"
   },
 

--- a/src/Router/ParameterResolvingRouter.php
+++ b/src/Router/ParameterResolvingRouter.php
@@ -62,12 +62,17 @@ final class ParameterResolvingRouter implements RouterInterface, RequestMatcherI
     /**
      * {@inheritdoc}
      */
-    public function generate($name, $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
+    public function generate($name, $unresolvedParameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
     {
-        $resolvedParameters = $this->resolverCollection->resolve($parameters);
+        $parameters = $this->resolverCollection->resolve($unresolvedParameters);
         $unresolved = [];
 
-        foreach ($resolvedParameters as $key => $parameter) {
+        foreach ($parameters as $key => $parameter) {
+            // should skip parameters that didn't need resolving
+            if ($parameter === $unresolvedParameters[$key]) {
+                continue;
+            }
+
             // sanity check for parameters that could not be resolved at all
             if (!is_scalar($parameter)) {
                 $unresolved[$key] = is_object($parameter) ? get_class($parameter): gettype($parameter);
@@ -85,7 +90,7 @@ final class ParameterResolvingRouter implements RouterInterface, RequestMatcherI
             throw new UnresolvedParameterException($name, $unresolved);
         }
 
-        return $this->router->generate($name, $this->resolverCollection->resolve($parameters), $referenceType);
+        return $this->router->generate($name, $parameters, $referenceType);
     }
 
     /**

--- a/test/Functional/Fixtures/config/routing.yml
+++ b/test/Functional/Fixtures/config/routing.yml
@@ -18,3 +18,6 @@ authentication_route:
 
 message_route:
     path: /message/{message}
+
+login:
+    path: /login

--- a/test/Functional/RouteGenerationTest.php
+++ b/test/Functional/RouteGenerationTest.php
@@ -9,6 +9,8 @@ use Iltar\HttpBundle\Functional\Fixtures\Entity\Message;
 use Iltar\HttpBundle\Functional\Fixtures\Model\MappedPost;
 use Iltar\HttpBundle\Functional\Fixtures\Model\Post;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Http\HttpUtils;
 
 /**
  * @author Wouter J <wouter@wouterj.nl>
@@ -70,20 +72,44 @@ class RouteGenerationTest extends KernelTestCase
         $router->generate('message_route', ['blind_write' => new BlindWrite(10)]);
     }
 
-    /**
-     * @expectedException \Iltar\HttpBundle\Exception\UnresolvedParameterException
-     * @expectedExceptionMessage Parameters for the route 'mapped_fallback_route' could not be resolved to scalar values. Parameters: "object_key, empty_key, array_key, resource_key".
-     */
-    public function testEntityIdResolverWithWithoutAlternatives()
+    public function testIfUnresolvedValuesAreLeftAlone()
     {
         $router = static::$kernel->getContainer()->get('router');
 
-        $router->generate('mapped_fallback_route', [
+        self::assertSame('/post/10?empty_key=&normal_key=10', $router->generate('mapped_fallback_route', [
             'object_key' => new \stdClass(),
             'empty_key' => '',
             'array_key' => [],
             'normal_key' => '10',
             'resource_key' => fopen(__FILE__, 'rb'),
-        ]);
+            'post' => 10,
+        ]));
+    }
+
+    /**
+     * @dataProvider getUnresolvedData
+     *
+     * @expectedException \Iltar\HttpBundle\Exception\UnresolvedParameterException
+     * @expectedExceptionMessage Parameters for the route 'client_route' could not be resolved to scalar values. Parameters: "client".
+     */
+    public function testIfUnresolvedDataThrowsException($id)
+    {
+        static::$kernel->getContainer()->get('router')->generate('client_route', ['client' => new Client($id)]);
+    }
+
+    public function getUnresolvedData()
+    {
+        return [[''], [[]], [null], [['non empty' => 'array value']]];
+    }
+
+    public function testExpectHttpUtilsToWork()
+    {
+        $router = static::$kernel->getContainer()->get('router');
+        $utils = new HttpUtils($router);
+        $request = Request::create('/');
+        $request->attributes->set('_route_params', []);
+        $request->attributes->set('foobar', new \stdClass());
+
+        self::assertSame('http://localhost/login', $utils->generateUri($request, 'login'));
     }
 }


### PR DESCRIPTION
This fix will make sure that only values that have changed by the resolver will be validated. The http utils from Symfony will always attempt to create a route with _all_ attributes in the request, which would cause generation to fail. This should ensure that only resolvable values are throwing exceptions if it failed to resolve to a valid value.

The only edge case I have not taken into account, is when an object is passed this way "by accident" and still resolves into something, but I don't think this would cause any harm unless this object is an entity and not flushed (but shouldn't be in that attribute bag in the first place).

The case that triggers this, is in the HttpUtils:
```php
$url = $this->urlGenerator->generate($path, $request->attributes->all(), UrlGeneratorInterface::ABSOLUTE_URL);

// unnecessary query string parameters must be removed from URL
// (ie. query parameters that are presents in $attributes)
// fortunately, they all are, so we have to remove entire query string
$position = strpos($url, '?');
if (false !== $position) {
    $url = substr($url, 0, $position);
}
```
```
{
    "class": "Iltar\\HttpBundle\\Exception\\UnresolvedParameterException",
    "message": "Parameters for the route 'app.authentication.login' could not be resolved to scalar values. Parameters: \"_route_params\".",
    "code": 0,
    "file": "/home/prod/mijn/12.15.82____0/vendor/iltar/http-bundle/src/Router/ParameterResolvingRouter.php:85",
    "trace": [
        "/home/prod/mijn/12.15.82____0/vendor/symfony/symfony/src/Symfony/Component/Security/Http/HttpUtils.php:146",
        "/home/prod/mijn/12.15.82____0/vendor/symfony/symfony/src/Symfony/Component/Security/Http/HttpUtils.php:61",
        "/home/prod/mijn/12.15.82____0/vendor/symfony/symfony/src/Symfony/Component/Security/Http/EntryPoint/FormAuthenticationEntryPoint.php:63",
        "/home/prod/mijn/12.15.82____0/vendor/symfony/symfony/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php:208",
        "/home/prod/mijn/12.15.82____0/vendor/symfony/symfony/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php:135",
        "/home/prod/mijn/12.15.82____0/vendor/symfony/symfony/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php:100",
        "{\"function\":\"onKernelException\",\"class\":\"Symfony\\\\Component\\\\Security\\\\Http\\\\Firewall\\\\ExceptionListener\",\"type\":\"->\",\"args\":[\"[object] (Symfony\\\\Component\\\\HttpKernel\\\\Event\\\\GetResponseForExceptionEvent: {})\",\"kernel.exception\",\"[object] (Symfony\\\\Component\\\\EventDispatcher\\\\ContainerAwareEventDispatcher: {})\"]}",
        "/home/prod/mijn/12.15.82____0/vendor/symfony/symfony/src/Symfony/Component/EventDispatcher/EventDispatcher.php:212",
        "/home/prod/mijn/12.15.82____0/vendor/symfony/symfony/src/Symfony/Component/EventDispatcher/EventDispatcher.php:44",
        "/home/prod/mijn/12.15.82____0/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php:230",
        "/home/prod/mijn/12.15.82____0/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php:79",
        "/home/prod/mijn/12.15.82____0/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Kernel.php:171",
        "/home/prod/mijn/12.15.82____0/web/app.php:20"
    ]
}
```